### PR TITLE
Use StoredProcedureRequestOptions in place of RequestOptions in C# example code

### DIFF
--- a/articles/cosmos-db/nosql/how-to-write-stored-procedures-triggers-udfs.md
+++ b/articles/cosmos-db/nosql/how-to-write-stored-procedures-triggers-udfs.md
@@ -412,7 +412,7 @@ console.log(responseHeaders[Constants.HttpHeaders.ScriptLogResults]);
 ```csharp
 var response = await client.ExecuteStoredProcedureAsync(
 document.SelfLink,
-new RequestOptions { EnableScriptLogging = true } );
+new StoredProcedureRequestOptions { EnableScriptLogging = true } );
 Console.WriteLine(response.ScriptLog);
 ```
 ---


### PR DESCRIPTION
Update C# example code to use `StoredProcedureRequestOptions` in place of `RequestOptions`

`StoredProcedureRequestOptions` has the `EnableScriptLogging` options shown in the docs