### PR TITLE
Correct --scope argument to dbs

### DIFF
--- a/articles/cosmos-db/nosql/security/how-to-grant-data-plane-role-based-access.md
+++ b/articles/cosmos-db/nosql/security/how-to-grant-data-plane-role-based-access.md
@@ -357,7 +357,7 @@ Now, assign the newly defined role to an identity so that your applications can 
         --account-name "<name-of-existing-nosql-account>" \
         --role-definition-id "<id-of-new-role-definition>" \
         --principal-id "<id-of-existing-identity>" \
-        --scope "/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/msdocs-identity-example/providers/Microsoft.DocumentDB/databaseAccounts/msdocs-identity-example-nosql"
+        --scope dbs
     ```
 
 1. Use [`az cosmosdb sql role assignment list`](/cli/azure/cosmosdb/sql/role/assignment#az-cosmosdb-sql-role-assignment-list) to list all role assignments for your Azure Cosmos DB for NoSQL account. Review the output to ensure your role assignment was created.


### PR DESCRIPTION
Trying to assign a scope based on an ARM resource id (as currently referenced in the docs) with the `az cosmosdb sql role assignment create` command results in the following error:

```
(BadRequest) Failed to parse the incoming request payload. Exception: System.FormatException: Could not parse property [properties] as [Microsoft.Azure.Documents.Management.Services.ResourceProvider.DataModel.RoleBasedAccessControl.SqlRoleAssignmentProperties] due to exception: System.FormatException: Could not parse property [scope] with value [/subscriptions/c188d79d-f4df-44c8-b9f1-0080b70a00b3/resourceGroups/rg-mlrpreflight-griff/providers/Microsoft.DocumentDB/databaseAccounts/cos-mlrgriff/subscriptions/c188d79d-f4df-44c8-b9f1-0080b70a00b3/resourceGroups/rg-mlrpreflight-griff/providers/Microsoft.DocumentDb/databaseAccounts/cos-mlrgriff] as [Microsoft.Azure.Documents.Management.Services.ResourceProvider.DataModel.RoleBasedAccessControl.FullyQualifiedResourcePath] due to exception: System.FormatException: Expected path segment [dbs] at position [0] but found [subscriptions].
```

I believe this should be `dbs` instead to assign to the database scope, which I've tested and works correctly.