### PR TITLE
docs[minor]: Remove extra backtick in code example

### DIFF
--- a/articles/cosmos-db/index-overview.md
+++ b/articles/cosmos-db/index-overview.md
@@ -305,7 +305,7 @@ Consider the following query:
 ```sql
 SELECT location
 FROM location IN company.locations
-WHERE location.country = 'France'`
+WHERE location.country = 'France'
 ```
 
 The query predicate (filtering on items where any location has "France" as its country/region) would match the path highlighted in this diagram:


### PR DESCRIPTION
Noticed an extra backtick in the Index Seek code example, thought I'd submit a quick PR to fix it.

Thanks!