### PR TITLE
Cosmos Always Encrypted misleading documentation about CMK key versions

### DIFF
--- a/articles/cosmos-db/how-to-always-encrypted.md
+++ b/articles/cosmos-db/how-to-always-encrypted.md
@@ -69,7 +69,7 @@ The first step to get started with Always Encrypted is to create your CMKs in Az
 
 1. Create a new Azure Key Vault instance or browse to an existing one.
 1. Create a new key in the **Keys** section.
-1. Once the key is created, browse to its current version, and copy its full key identifier:<br>`https://<my-key-vault>.vault.azure.net/keys/<key>/<version>`. If you omit the key version at the end of the key identifier, the latest version of the key is used.
+1. Once the key is created, browse to its current version, and copy its full key identifier:<br>`https://<my-key-vault>.vault.azure.net/keys/<key>/<version>`.
 
 Next, you need to configure how the Azure Cosmos DB SDK will access your Azure Key Vault instance. This authentication is done through a Microsoft Entra identity. Most likely, you'll use the identity of a Microsoft Entra application or a [managed identity](/azure/active-directory/managed-identities-azure-resources/overview) as the proxy between your client code and your Azure Key Vault instance, although any kind of identity could be used. Use the following steps to use your Microsoft Entra identity as the proxy:
 

--- a/articles/cosmos-db/how-to-always-encrypted.md
+++ b/articles/cosmos-db/how-to-always-encrypted.md
@@ -150,7 +150,7 @@ Creating a new data encryption key is done by calling the `CreateClientEncryptio
   - The `name` can be any friendly name you want.
   - The `value` must be the key identifier.
   > [!IMPORTANT]
-  > Once the key is created, browse to its current version, and copy its full key identifier: `https://<my-key-vault>.vault.azure.net/keys/<key>/<version>`. If you omit the key version at the end of the key identifier, the latest version of the key is used.
+  > Once the key is created, browse to its current version, and copy its full key identifier: `https://<my-key-vault>.vault.azure.net/keys/<key>/<version>`.
   - The `algorithm` defines which algorithm shall be used to wrap the key encryption key with the customer-managed key.
 
 ```csharp


### PR DESCRIPTION
The CreateClientEncryptionKeyAsync method requires the full path to the CMK key in KeyVault specified - it doesn't accept a key URL without the version. Thus you can't actually provide a non-version specific URL to the DEK.