### PR TITLE
Fix incomplete parameter in quickstart-nodejs.md

### DIFF
--- a/articles/cosmos-db/nosql/quickstart-nodejs.md
+++ b/articles/cosmos-db/nosql/quickstart-nodejs.md
@@ -140,7 +140,7 @@ This sample creates a new instance of the `CosmosClient` type and authenticates 
 const credential = new DefaultAzureCredential();
 
 const client = new CosmosClient({
-    '<azure-cosmos-db-nosql-account-endpoint>',
+    endpoint,
     aadCredentials: credential
 });
 ```
@@ -153,7 +153,7 @@ const client = new CosmosClient({
 const credential: TokenCredential = new DefaultAzureCredential();
 
 const client = new CosmosClient({
-    '<azure-cosmos-db-nosql-account-endpoint>',
+    endpoint,
     aadCredentials: credential
 });
 ```


### PR DESCRIPTION
Fixed the incomplete parameter in CosmosClient because the key `endpoint` was missing.
The notation has been aligned with [the sample program](https://github.com/Azure-Samples/cosmos-db-nosql-nodejs-quickstart/blob/dd405a5bcc85f9637d04e8fb744e93d807217c03/src/ts/cosmos.ts#L34).

### References
#### Other page related to instantiating CosmosClient
https://github.com/MicrosoftDocs/azure-databases-docs/blob/a395a9ddb4b1eba806f2ae636b3a26e08b82cdf5/articles/cosmos-db/nosql/how-to-javascript-get-started.md?plain=1#L87-L90