### PR TITLE
Update index-policy.md

### DIFF
--- a/articles/cosmos-db/index-policy.md
+++ b/articles/cosmos-db/index-policy.md
@@ -31,7 +31,7 @@ Azure Cosmos DB supports two indexing modes:
 > [!NOTE]
 > Azure Cosmos DB also supports a Lazy indexing mode. Lazy indexing performs updates to the index at a much lower priority level when the engine is not doing any other work. This can result in **inconsistent or incomplete** query results. If you plan to query an Azure Cosmos DB container, you should not select lazy indexing. New containers cannot select lazy indexing. You can request an exemption by contacting cosmosdbindexing@microsoft.com (except if you are using an Azure Cosmos DB account in [serverless](serverless.md) mode which doesn't support lazy indexing).
 
-By default, indexing policy is set to `automatic`. It's achieved by setting the `automatic` property in the indexing policy to `true`. Setting this property to `true` allows Azure Cosmos DB to automatically index items as they're written.
+
 
 ## Index size
 


### PR DESCRIPTION
Suggest removing the paragraph "By default, indexing policy is set to automatic. It's achieved by setting the automatic property in the indexing policy to true. Setting this property to true allows Azure Cosmos DB to automatically index items as they're written.". It is confusing because if indexing mode is consistent, they appear to do the same thing. There doesn't appear to be a scenario where it is set to false.