### PR TITLE
Supported versions - fix typo in title

### DIFF
--- a/articles/postgresql/flexible-server/concepts-supported-versions.md
+++ b/articles/postgresql/flexible-server/concepts-supported-versions.md
@@ -1,5 +1,5 @@
 ---
-title: Supported versions of PosgtreSQL
+title: Supported versions of PostgreSQL
 description: Describes the supported major and minor versions of PostgreSQL in Azure Database for PostgreSQL - Flexible Server.
 author: varun-dhawan
 ms.author: varundhawan


### PR DESCRIPTION
I've noticed this typo when checking if 17 is available already.