### PR TITLE
Update indexing.md - as per previous commit 1569d9d, where the feature was removed

### DIFF
--- a/articles/cosmos-db/mongodb/indexing.md
+++ b/articles/cosmos-db/mongodb/indexing.md
@@ -191,9 +191,6 @@ You can also create wildcard indexes using the Data Explorer in the Azure portal
 
 Documents with many fields may have a high Request Unit (RU) charge for writes and updates. Therefore, if you have a write-heavy workload, you should opt to individually index paths as opposed to using wildcard indexes.
 
-> [!NOTE]
-> Support for unique index on existing collections with data is available in preview. This feature can be enabled for your database account by enabling the ['EnableUniqueIndexReIndex' capability](./how-to-configure-capabilities.md#available-capabilities).
-
 ### Limitations
 
 Wildcard indexes do not support any of the following index types or properties:


### PR DESCRIPTION
As the title mentions. The PR is to align an orphan reference to CosmosDB for MongoDB capabilities. The mentioned capability is no longer available.

![image](https://github.com/user-attachments/assets/332e335a-084e-4c6c-8de5-96b87694a693)
