### PR TITLE
Cosmos: Update Cosmos min recommended version to 3.47.0

### DIFF
--- a/articles/cosmos-db/nosql/sdk-dotnet-v3.md
+++ b/articles/cosmos-db/nosql/sdk-dotnet-v3.md
@@ -32,7 +32,7 @@ Release history is maintained in the Azure Cosmos DB .NET SDK source repo. For a
 
 ## <a name="recommended-version"></a> Recommended version
 
-Different sub versions of .NET SDKs are available under the 3.x.x version. **The minimum recommended version is 3.35.4**.
+Different sub versions of .NET SDKs are available under the 3.x.x version. **The minimum recommended version is 3.47.0**.
 
 ## <a name="known-issues"></a> Known issues
 


### PR DESCRIPTION
Changes the minimum recommended version of the Cosmos DB .NET SDK to 3.47.0
see:
https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/changelog.md#-recommended-version