### PR TITLE
Update Cosmos DB change feed docs with missing properties for delete operations.

### DIFF
--- a/articles/cosmos-db/nosql/change-feed-modes.md
+++ b/articles/cosmos-db/nosql/change-feed-modes.md
@@ -180,6 +180,9 @@ The response object is an array of items that represent each change. Different p
         "partitionKey": {
           "<Partition key property name>": "<Partition key property value>"
         }
+      },
+      "previous": {
+        <The version of the item at the time it was deleted. All the properties of your item will appear here.>
       }
     }
     ```


### PR DESCRIPTION
Update documentation on all versions and deletes change feed mode to reflect that delete operation response objects contain the version of the item at deletion time.

I understand not all the features in the preview might want to be documented, but the .NET SDK (preview version) is already expecting this property to exist ([ChangeFeedItem.cs#78](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/f07e7976e483ef2431622a6f3157f1d7ca7069d0/Microsoft.Azure.Cosmos/src/Resource/FullFidelity/ChangeFeedItem.cs#L78)), so I assumed this is a documentation oversight 😃