### PR TITLE
Update Extension Identifier in Link to VS Code Marketplace

### DIFF
--- a/articles/postgresql/extensions/vs-code-extension/overview.md
+++ b/articles/postgresql/extensions/vs-code-extension/overview.md
@@ -91,4 +91,4 @@ For bugs, feature requests, and issues, use the built-in feedback tool in Visual
 
 - [Quickstart: Connect and query a database with the PostgreSQL extension for Visual Studio Code preview](quickstart-connect.md)
 - [Quickstart: Configure GitHub Copilot for PostgreSQL extension in Visual Studio Code preview](quickstart-github-copilot.md)
-- [PostgreSQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-postgresql)
+- [PostgreSQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-pgsql)

--- a/articles/postgresql/extensions/vs-code-extension/quickstart-connect.md
+++ b/articles/postgresql/extensions/vs-code-extension/quickstart-connect.md
@@ -197,4 +197,4 @@ For bugs, feature requests, and issues, use the built-in feedback tool in Visual
 
 - [What is the PostgreSQL extension for Visual Studio Code preview?](overview.md)
 - [Quickstart: Configure GitHub Copilot for PostgreSQL extension in Visual Studio Code preview](quickstart-github-copilot.md)
-- [PostgreSQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-postgresql)
+- [PostgreSQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-pgsql)

--- a/articles/postgresql/extensions/vs-code-extension/quickstart-github-copilot.md
+++ b/articles/postgresql/extensions/vs-code-extension/quickstart-github-copilot.md
@@ -163,4 +163,4 @@ For bugs, feature requests, and issues, use the built-in feedback tool in Visual
 
 - [What is the PostgreSQL extension for Visual Studio Code preview?](overview.md)
 - [Quickstart: Connect and query a database with the PostgreSQL extension for Visual Studio Code preview](quickstart-connect.md)
-- [PostgreSQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-postgresql)
+- [PostgreSQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-pgsql)


### PR DESCRIPTION
The link in these pages are currently pointing to a 404 page on the Marketplace, likely due to a change in the extension id.