### PR TITLE
Update concepts-read-replicas-promote.md

### DIFF
--- a/articles/postgresql/flexible-server/concepts-read-replicas-promote.md
+++ b/articles/postgresql/flexible-server/concepts-read-replicas-promote.md
@@ -53,7 +53,7 @@ For both promotion methods, there are more options to consider:
 > The **Forced** promotion option is designed to address regional outages and, in such cases, it skips all checks - including the server symmetry requirement - and proceeds with promotion. This is because it prioritizes immediate server availability to handle disaster scenarios. However, using the Forced option outside of region down scenarios isn't allowed if the requirements for read replicas specified in the documentation, especially server symmetry requirement, aren't met, as it could lead to issues such as broken replication.
  
 
-Learn how to [promote replica to primary](how-to-read-replicas-portal.md#promote-replicas) and [promote to independent server and remove from replication](how-to-read-replicas-portal.md#promote-replica-to-independent-server).
+Learn how to [promote replica to primary](how-to-read-replicas-portal.md#promote-replicas) and [promote to independent server and remove from replication](how-to-promote-replica-to-standalone.md#promote-replica-to-independent-server).
 
 ## Configuration management
 


### PR DESCRIPTION
Existing link is pointing to wrong page.  Should be pointing to this URL: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-promote-replica-to-standalone?tabs=portal-promote-replica-to-standalone-server