### PR TITLE
Update compatibility notes for MongoDB commands searchMeta results to be supported

### DIFF
--- a/articles/cosmos-db/mongodb/vcore/compatibility-and-feature-support.md
+++ b/articles/cosmos-db/mongodb/vcore/compatibility-and-feature-support.md
@@ -30,7 +30,6 @@ The following table lists commands not supported/restricted by the database. As 
 <tr><td>$function</td></tr>
 <tr><td>$where</td></tr>
 
-<tr><td>$searchMeta</td><td rowspan="4">It's not prioritized at this time due to low demand.</td></tr>
 <tr><td>$listSearchIndexes</td></tr>
 <tr><td>$listSampledQueries</td></tr>
 <tr><td>$shardedDataDistribution</td></tr>


### PR DESCRIPTION
Based on this part of the  documentation https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/compatibility searchMeta is now supported thus the request to remove from the unsupported commands 