### PR TITLE
Update compatibility notes searchMeta appears to be supported

### DIFF
--- a/articles/cosmos-db/mongodb/vcore/compatibility-and-feature-support.md
+++ b/articles/cosmos-db/mongodb/vcore/compatibility-and-feature-support.md
@@ -30,8 +30,7 @@ The following table lists commands not supported/restricted by the database. As 
 <tr><td>$function</td></tr>
 <tr><td>$where</td></tr>
 
-<tr><td>$searchMeta</td><td rowspan="4">It's not prioritized at this time due to low demand.</td></tr>
-<tr><td>$listSearchIndexes</td></tr>
+<tr><td>$listSearchIndexes</td><td rowspan="3">It's not prioritized at this time due to low demand.</td></tr>
 <tr><td>$listSampledQueries</td></tr>
 <tr><td>$shardedDataDistribution</td></tr>
 


### PR DESCRIPTION
According to this piece of the documentation https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/compatibility the searchMeta aggregation pipeline operator is  . I've moved the comment to the following line that is listSearchIndex