### PR TITLE
Fix endpoint syntax error in Cosmos DB quickstart

### DIFF
--- a/articles/cosmos-db/nosql/quickstart-nodejs.md
+++ b/articles/cosmos-db/nosql/quickstart-nodejs.md
@@ -165,7 +165,7 @@ This sample creates a new instance of the `CosmosClient` type and authenticates 
 const credential = new DefaultAzureCredential();
 
 const client = new CosmosClient({
-    '<azure-cosmos-db-nosql-account-endpoint>',
+    endpoint: '<azure-cosmos-db-nosql-account-endpoint>',
     aadCredentials: credential
 });
 ```
@@ -178,7 +178,7 @@ const client = new CosmosClient({
 const credential: TokenCredential = new DefaultAzureCredential();
 
 const client = new CosmosClient({
-    '<azure-cosmos-db-nosql-account-endpoint>',
+    endpoint: '<azure-cosmos-db-nosql-account-endpoint>',
     aadCredentials: credential
 });
 ```


### PR DESCRIPTION
The previous syntax was not valid (it's not permitted to have a value without a key in an object definition), so I add the `endpoint: ` key before the endpoint string