### PR TITLE
docs: add PowerShell tab for az resource patch command in change streams

### DIFF
--- a/articles/documentdb/change-streams.md
+++ b/articles/documentdb/change-streams.md
@@ -38,9 +38,19 @@ az resource show --ids "/subscriptions/<sub id>/resourceGroups/<resource group n
 
 3. Send PATCH request to enable the feature.
 
+# [Bash](#tab/bash)
+
 ```bash
 az resource patch --ids "/subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/Microsoft.DocumentDB/mongoClusters/<cluster-name>" --api-version 2024-10-01-preview --properties "{\"previewFeatures\": [ \"ChangeStreams\"]}"
 ```
+
+# [PowerShell](#tab/powershell)
+
+```powershell
+az resource patch --ids "/subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/Microsoft.DocumentDB/mongoClusters/<cluster-name>" --api-version 2024-10-01-preview --properties '{\"previewFeatures\": [\"ChangeStreams\"]}'
+```
+
+---
 
 4. Verify result:
    - Ensure the response payload includes `"previewFeatures": ["ChangeStreams"]`.


### PR DESCRIPTION
## Problem

The `az resource patch` command in the [Change Streams](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/change-streams) article uses Bash-style JSON escaping (`\"`), which does not work in PowerShell. PowerShell handles quote escaping differently, causing the command to fail when users copy-paste it directly.

## Fix

Added a tabbed section (Bash / PowerShell) so users on either shell get the correct command syntax:

- **Bash**: keeps the existing `\"...\"` escaping (unchanged)
- **PowerShell**: uses single-quoted string with `'\\\"` escaping that PowerShell handles correctly

## Document

- **URL**: https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/change-streams
- **Source**: `articles/documentdb/change-streams.md`
