### PR TITLE
Update quickstart-create-connect-server-vnet.md

### DIFF
--- a/articles/postgresql/connectivity/quickstart-create-connect-server-vnet.md
+++ b/articles/postgresql/connectivity/quickstart-create-connect-server-vnet.md
@@ -140,7 +140,7 @@ sudo apt-get install postgresql-client
 Connections to the database are enforced with SSL, hence you need to download the public SSL certificate.
 
 ```bash
-wget --no-check-certificate https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem
+wget --no-check-certificate https://cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem
 ```
 
 ## Connect to the server from Azure Linux virtual machine


### PR DESCRIPTION
Link to download public SSL certificate was erroneous in the proposed wget command. Found the correct link in https://learn.microsoft.com/en-us/azure/mysql/flexible-server/security-tls-root-certificate-rotation