### PR TITLE
Correct public_network_access_enabled setting in migration guide

### DIFF
--- a/articles/postgresql/network/how-to-migrate-vnet-private-endpoint-capable-server.md
+++ b/articles/postgresql/network/how-to-migrate-vnet-private-endpoint-capable-server.md
@@ -87,7 +87,7 @@ For more information, see [Add private endpoint connections to Azure Database fo
 After the VNet to PE-capable network migration, the server is no longer VNet-integrated. If you have Terraform configurations, update them accordingly:
 
 - Remove `delegated_subnet_id` from the PostgreSQL server resource.
-- Ensure `public_network_access_enabled` remains `true` (this value is the post-migration default).
+- Ensure `public_network_access_enabled` remains `false` (this value is the post-migration default).
 
 ## Related content
 


### PR DESCRIPTION
Updated the documentation to reflect that 'public_network_access_enabled' should be set to false after migration. validated after a test