### PR TITLE
Correct audience value in integration documentation

### DIFF
--- a/articles/postgresql/azure-ai/generative-ai-foundry-integration.md
+++ b/articles/postgresql/azure-ai/generative-ai-foundry-integration.md
@@ -235,10 +235,10 @@ After you deploy your MCP server, connect it to Foundry:
 
    :::image type="content" source="media/generative-ai-foundry-integration/ai-foundry-postgresql-tool-catalog.png" alt-text="Screenshot of Managed Identity page for the PostgreSQL tool." lightbox="media/generative-ai-foundry-integration/ai-foundry-postgresql-tool-catalog.png" :::
 
-1. Enter the `ENTRA_APP_CLIENT_ID` value as the audience. This value is from the output of the `azd env get-values` command.
+1. Enter the `ENTRA_APP_IDENTIFIER_URI` value as the audience. This value is from the output of the `azd env get-values` command.
 
    > [!TIP]  
-   > Use `azd env get-values` command to find the `ENTRA_APP_CLIENT_ID` and `CONTAINER_APP_URL` values.
+   > Use `azd env get-values` command to find the `ENTRA_APP_IDENTIFIER_URI` and `CONTAINER_APP_URL` values. The `ENTRA_APP_IDENTIFIER_URI` starts with `apo://`.
 
 1. Select **Save** to save your progress on the agent creation.
 

--- a/articles/postgresql/azure-ai/generative-ai-foundry-integration.md
+++ b/articles/postgresql/azure-ai/generative-ai-foundry-integration.md
@@ -238,7 +238,7 @@ After you deploy your MCP server, connect it to Foundry:
 1. Enter the `ENTRA_APP_IDENTIFIER_URI` value as the audience. This value is from the output of the `azd env get-values` command.
 
    > [!TIP]  
-   > Use `azd env get-values` command to find the `ENTRA_APP_IDENTIFIER_URI` and `CONTAINER_APP_URL` values. The `ENTRA_APP_IDENTIFIER_URI` starts with `apo://`.
+   > Use `azd env get-values` command to find the `ENTRA_APP_IDENTIFIER_URI` and `CONTAINER_APP_URL` values. The `ENTRA_APP_IDENTIFIER_URI` starts with `api://`.
 
 1. Select **Save** to save your progress on the agent creation.
 


### PR DESCRIPTION
Updated audience value from 'ENTRA_APP_CLIENT_ID' to 'ENTRA_APP_IDENTIFIER_URI' and modified related tip for clarity. ENTRA_APP_CLIENT_ID causes 401 error and is not recognized by the container apps